### PR TITLE
Add academic validation docs and model comparison

### DIFF
--- a/ACADEMIC_VALIDATION_STATUS.md
+++ b/ACADEMIC_VALIDATION_STATUS.md
@@ -1,0 +1,41 @@
+# Academic Validation Status
+
+## ⚠️ Current Status: Validation Infrastructure Ready
+
+nobtium provides a comprehensive framework for AI safety monitoring with robust statistical analysis capabilities. However, **rigorous empirical validation with large-scale real-world datasets is required** before making definitive performance claims.
+
+### What This System Provides:
+✅ Comprehensive multi-modal anomaly detection algorithms
+✅ Statistical analysis and validation framework
+✅ Benchmarking and evaluation infrastructure
+✅ Reproducible research protocols
+✅ Open-source foundation for community validation
+
+### What The Research Community Needs To Provide:
+🔄 Large-scale real-world AI interaction datasets (10k+ samples)
+🔄 Expert human annotation of anomalies and normal behavior
+🔄 Multi-environment validation across different AI systems
+🔄 Independent third-party evaluation studies
+🔄 Longitudinal studies across different time periods
+
+### Current Validation Status:
+- **Synthetic Data**: ✅ Validated on constructed test cases
+- **Real-world Data**: ⚠️ Requires community contribution
+- **Cross-system Validation**: ⚠️ Pending multi-platform studies
+- **Long-term Stability**: ⚠️ Requires extended deployment data
+
+### Suitable Current Uses:
+✅ Research infrastructure development
+✅ Preliminary anomaly detection exploration
+✅ Framework development and testing
+✅ Foundation for validation studies
+✅ Educational and demonstration purposes
+
+### Community Research Opportunities:
+1. **Dataset Contribution**: Share anonymized AI interaction logs
+2. **Validation Studies**: Conduct independent evaluation research
+3. **Cross-system Testing**: Validate across different AI platforms
+4. **Improvement Contributions**: Enhance detection algorithms
+5. **Academic Collaboration**: Co-author validation papers
+
+**Note**: All performance metrics should be considered preliminary pending comprehensive empirical validation by the research community.

--- a/ModelComparison.js
+++ b/ModelComparison.js
@@ -1,0 +1,2 @@
+const ModelComparison = require('./scripts/model_comparison');
+module.exports = ModelComparison;

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ node analyzeLogs.js nobtium_log.json --validate
 
 This generates `benchmark_stats.json` and updates `academic_dashboard.html` with confidence intervals from the benchmark suite. Parameters can be tweaked in `.env` under **Academic validation settings**.
 
+See [ACADEMIC_VALIDATION_STATUS.md](ACADEMIC_VALIDATION_STATUS.md) for a detailed overview of current validation limitations and community research opportunities.
+
 ## 📂 Directory Structure
 
 ```

--- a/scripts/benchmark_framework.js
+++ b/scripts/benchmark_framework.js
@@ -30,7 +30,8 @@ class BenchmarkFramework {
             trueNegatives: 0,
             falseNegatives: 0,
             detectionTimes: [],
-            confidenceScores: []
+            confidenceScores: [],
+            memoryUsage: []
         };
     }
     
@@ -106,11 +107,14 @@ class BenchmarkFramework {
             
             for (const testCase of testCases) {
                 const startTime = Date.now();
+                const memBefore = process.memoryUsage().heapUsed;
                 const detection = await detectionFunction(testCase.content);
+                const memAfter = process.memoryUsage().heapUsed;
                 const endTime = Date.now();
                 
                 const result = this.evaluateDetection(testCase, detection);
                 result.processingTime = endTime - startTime;
+                result.memoryUsage = memAfter - memBefore;
                 result.dataset = datasetName;
                 
                 results.detailedResults.push(result);
@@ -244,6 +248,9 @@ class BenchmarkFramework {
     
     updateMetrics(result) {
         this.results.detectionTimes.push(result.processingTime);
+        if (typeof result.memoryUsage === 'number') {
+            this.results.memoryUsage.push(result.memoryUsage);
+        }
         
         // Store confidence scores for statistical analysis
         if (result.detection) {
@@ -267,7 +274,10 @@ class BenchmarkFramework {
             performance: {
                 avgProcessingTime: this.calculateAverage(this.results.detectionTimes).toFixed(2) + 'ms',
                 maxProcessingTime: Math.max(...this.results.detectionTimes) + 'ms',
-                minProcessingTime: Math.min(...this.results.detectionTimes) + 'ms'
+                minProcessingTime: Math.min(...this.results.detectionTimes) + 'ms',
+                avgMemoryUsage: this.calculateAverage(this.results.memoryUsage).toFixed(0) + 'B',
+                maxMemoryUsage: Math.max(...this.results.memoryUsage) + 'B',
+                minMemoryUsage: Math.min(...this.results.memoryUsage) + 'B'
             },
             confusionMatrix: {
                 truePositives: results.overall.truePositives,

--- a/scripts/model_comparison.js
+++ b/scripts/model_comparison.js
@@ -1,0 +1,62 @@
+/*
+ * nobtium AI Safety Monitoring System \u03c0
+ * Model Comparison Engine for academic analysis
+ */
+
+const StatisticalValidator = require('./statistical_validator');
+
+class ModelComparison {
+  constructor(models = []) {
+    this.models = models; // [{ name, predict(text) -> score }]
+    this.validator = new StatisticalValidator();
+  }
+
+  async run(data) {
+    const labels = data.map(d => d.label);
+    const outcomes = [];
+
+    for (const model of this.models) {
+      const start = Date.now();
+      const memBefore = process.memoryUsage().heapUsed;
+      const preds = [];
+      for (const item of data) {
+        const p = await model.predict(item.text);
+        preds.push(p);
+      }
+      const memAfter = process.memoryUsage().heapUsed;
+      const end = Date.now();
+      const binary = preds.map(p => p >= 0.5);
+      const metrics = this.validator.calculateBinaryMetrics(binary, labels);
+      outcomes.push({
+        name: model.name,
+        metrics,
+        predictions: binary,
+        processingTime: end - start,
+        memoryUsage: memAfter - memBefore
+      });
+    }
+
+    return outcomes;
+  }
+
+  mcnemarsTest(predA, predB, labels) {
+    let n01 = 0;
+    let n10 = 0;
+    for (let i = 0; i < labels.length; i++) {
+      const aCorrect = predA[i] === labels[i];
+      const bCorrect = predB[i] === labels[i];
+      if (aCorrect && !bCorrect) n10++;
+      else if (!aCorrect && bCorrect) n01++;
+    }
+    const chiSquare = Math.pow(Math.abs(n01 - n10) - 1, 2) / ((n01 + n10) || 1);
+    return { n01, n10, chiSquare };
+  }
+
+  compareSignificance(resultA, resultB, metric = 'f1Score') {
+    const a = [resultA.metrics[metric] || 0];
+    const b = [resultB.metrics[metric] || 0];
+    return this.validator.performTTest(a, b);
+  }
+}
+
+module.exports = ModelComparison;


### PR DESCRIPTION
## Summary
- integrate memory usage stats in benchmark framework
- document academic validation status
- add model comparison engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863a5c05a408321b96a38180ff377ee