### PR TITLE
Add Comprehension Strategy Engine

### DIFF
--- a/scripts/comprehension_strategy_engine.js
+++ b/scripts/comprehension_strategy_engine.js
@@ -1,0 +1,66 @@
+/*
+ * nobtium Meta-Understanding System - Comprehension Strategy Engine
+ * Built for the future of human-AI cooperation \u03c0
+ *
+ * Ethical Principles:
+ * - Human dignity is sacred
+ * - Privacy is a fundamental right
+ * - AI creativity must flourish safely
+ * - Power requires responsibility
+ * - Transparency builds trust
+ *
+ * See ETHICAL_MANIFESTO.md for complete principles
+ */
+
+'use strict';
+
+const strategyMap = {
+  temporal_complexity: {
+    approach: 'temporal_transformation',
+    tools: ['time_series_analysis', 'event_detection'],
+    human_action: 'Analyze in time slices, slow down observation',
+    safety_level: 'medium',
+    urgency: 'normal',
+  },
+  semantic_ambiguity: {
+    approach: 'semantic_clarification',
+    tools: ['topic_modeling', 'disambiguation'],
+    human_action: 'Seek clearer wording and confirm intended meaning',
+    safety_level: 'low',
+    urgency: 'normal',
+  },
+  structural_entropy: {
+    approach: 'pattern_restructuring',
+    tools: ['sequence_alignment', 'noise_filtering'],
+    human_action: 'Reorganize data streams, remove noise',
+    safety_level: 'medium',
+    urgency: 'high',
+  },
+  cognitive_overload: {
+    approach: 'load_balancing',
+    tools: ['summarization', 'attention_guidance'],
+    human_action: 'Break tasks into parts and focus attention stepwise',
+    safety_level: 'high',
+    urgency: 'immediate',
+  },
+};
+
+function getComprehensionStrategy(classification) {
+  if (!classification || typeof classification !== 'object') {
+    return null;
+  }
+  return strategyMap[classification.type] || null;
+}
+
+if (require.main === module) {
+  console.log('nobtium Meta-Understanding System - Strategy Engine');
+  const example = {
+    type: 'temporal_complexity',
+    confidence: 0.78,
+    reasoning: '...',
+    indicators: ['high_entropy', 'temporal_variance'],
+  };
+  console.log(JSON.stringify(getComprehensionStrategy(example), null, 2));
+}
+
+module.exports = { getComprehensionStrategy };

--- a/test/comprehensionStrategyEngine.test.js
+++ b/test/comprehensionStrategyEngine.test.js
@@ -1,0 +1,19 @@
+const { getComprehensionStrategy } = require('../scripts/comprehension_strategy_engine');
+
+test('returns strategy for known classification type', () => {
+  const classification = { type: 'temporal_complexity' };
+  const strategy = getComprehensionStrategy(classification);
+  expect(strategy).toEqual({
+    approach: 'temporal_transformation',
+    tools: ['time_series_analysis', 'event_detection'],
+    human_action: 'Analyze in time slices, slow down observation',
+    safety_level: 'medium',
+    urgency: 'normal',
+  });
+});
+
+test('returns null for unknown classification type', () => {
+  const classification = { type: 'unknown_type' };
+  const strategy = getComprehensionStrategy(classification);
+  expect(strategy).toBeNull();
+});


### PR DESCRIPTION
## Summary
- implement `comprehension_strategy_engine.js` with a static mapping of strategies
- support CLI usage example when run directly
- add tests for the new strategy engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686937b4c8f48321b5f7f8d5f68d8c95