### PR TITLE
Add Meta-Understanding tests and modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ npm test
 
 Run this to execute the Jest unit tests.
 
+The suite now includes checks for the Meta-Understanding classifier and strategy
+engine as well as an end-to-end workflow test.
+
 ## 🎓 Academic Validation
 
 Enable advanced statistical validation by passing the `--validate` flag when running `analyzeLogs.js`:
@@ -201,6 +204,9 @@ examples/              Sample code
 scripts/               Analysis and alert scripts
 scores/                Sample score output
 views/                 EJS templates
+classifier.js          Simple log classifier
+strategyEngine.js      Strategy selection helper
+metaWorkflow.js        Integration workflow
 compare.html           UI for comparison
 react_dashboard.html   React summary dashboard
 webDashboard.js        Express dashboard server

--- a/classifier.js
+++ b/classifier.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function classifyEntry(message) {
+  if (typeof message !== 'string' || !message.trim()) {
+    return 'unknown';
+  }
+  if (/(.)\1{4,}/.test(message)) {
+    return 'anomaly';
+  }
+  if (/[^\x00-\x7F]/.test(message)) {
+    return 'warning';
+  }
+  return 'normal';
+}
+
+module.exports = { classifyEntry };

--- a/metaWorkflow.js
+++ b/metaWorkflow.js
@@ -1,0 +1,16 @@
+'use strict';
+const { classifyEntry } = require('./classifier');
+const { chooseStrategy } = require('./strategyEngine');
+const { structuralAnomaly } = require('./scores/unperceived_score');
+
+function analyzeEntry(entry, history = []) {
+  if (!entry || typeof entry.message !== 'string') {
+    throw new Error('Invalid entry');
+  }
+  const classification = classifyEntry(entry.message);
+  const strategy = chooseStrategy(classification);
+  const score = structuralAnomaly(entry.message);
+  return { classification, strategy, score };
+}
+
+module.exports = { analyzeEntry };

--- a/strategyEngine.js
+++ b/strategyEngine.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function chooseStrategy(classification) {
+  switch (classification) {
+    case 'anomaly':
+      return 'strict';
+    case 'warning':
+      return 'medium';
+    case 'normal':
+      return 'basic';
+    default:
+      return 'unknown';
+  }
+}
+
+module.exports = { chooseStrategy };

--- a/test/classifier.test.js
+++ b/test/classifier.test.js
@@ -1,0 +1,20 @@
+const { classifyEntry } = require('../classifier');
+
+describe('classifyEntry', () => {
+  test('detects anomaly with repeated characters', () => {
+    expect(classifyEntry('aaaaabbbbb')).toBe('anomaly');
+  });
+
+  test('flags warning for non-ascii', () => {
+    expect(classifyEntry('hello世界')).toBe('warning');
+  });
+
+  test('normal text', () => {
+    expect(classifyEntry('hello world')).toBe('normal');
+  });
+
+  test('handles invalid input', () => {
+    expect(classifyEntry('')).toBe('unknown');
+    expect(classifyEntry(null)).toBe('unknown');
+  });
+});

--- a/test/endToEndWorkflow.test.js
+++ b/test/endToEndWorkflow.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const { analyzeEntry } = require('../metaWorkflow');
+
+test('processes log file end-to-end', () => {
+  const tmp = path.join(__dirname, 'tmp_log.json');
+  const log = [
+    { message: 'hello world' },
+    { message: '!!!!!?????' },
+    { message: 'ok' }
+  ];
+  fs.writeFileSync(tmp, JSON.stringify(log));
+  const data = JSON.parse(fs.readFileSync(tmp, 'utf8'));
+  const results = data.map(analyzeEntry);
+  expect(results[0].classification).toBe('normal');
+  expect(results[1].strategy).toBe('strict');
+  expect(results[2].score).toBe(1);
+  fs.unlinkSync(tmp);
+});

--- a/test/metaWorkflow.test.js
+++ b/test/metaWorkflow.test.js
@@ -1,0 +1,19 @@
+const { analyzeEntry } = require('../metaWorkflow');
+
+describe('analyzeEntry integration', () => {
+  test('returns classification, strategy, and score', () => {
+    const entry = { message: 'hello world' };
+    const out = analyzeEntry(entry);
+    expect(out.classification).toBe('normal');
+    expect(out.strategy).toBe('basic');
+    expect(out.score).toBe(0);
+  });
+
+  test('handles anomaly path', () => {
+    const entry = { message: '!!!!!?????' };
+    const out = analyzeEntry(entry);
+    expect(out.classification).toBe('anomaly');
+    expect(out.strategy).toBe('strict');
+    expect(out.score).toBe(1);
+  });
+});

--- a/test/strategyEngine.test.js
+++ b/test/strategyEngine.test.js
@@ -1,0 +1,19 @@
+const { chooseStrategy } = require('../strategyEngine');
+
+describe('chooseStrategy', () => {
+  test('returns strict for anomaly', () => {
+    expect(chooseStrategy('anomaly')).toBe('strict');
+  });
+
+  test('returns medium for warning', () => {
+    expect(chooseStrategy('warning')).toBe('medium');
+  });
+
+  test('returns basic for normal', () => {
+    expect(chooseStrategy('normal')).toBe('basic');
+  });
+
+  test('unknown classification', () => {
+    expect(chooseStrategy('other')).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `classifier`, `strategyEngine` and `metaWorkflow`
- add corresponding unit, integration and E2E tests
- document new modules in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68693ba49014832195d73ab7f08f482a